### PR TITLE
initial Python 3 compatibility

### DIFF
--- a/WonderPy/components/__init__.py
+++ b/WonderPy/components/__init__.py
@@ -1,20 +1,20 @@
-from wwCommandBase import WWCommandBase                  # noqa
-from wwCommandAccessory import WWCommandAccessory        # noqa
-from wwCommandBody import WWCommandBody                  # noqa
-from wwCommandEyering import WWCommandEyering            # noqa
-from wwCommandHead import WWCommandHead                  # noqa
-from wwCommandMedia import WWCommandMedia                # noqa
-from wwCommandMonoLED import WWCommandMonoLED            # noqa
-from wwCommandPing import WWCommandPing                  # noqa
-from wwCommandRGB import WWCommandRGB                    # noqa
-from wwMedia import WWMedia                              # noqa
-from wwSensorAccelerometer import WWSensorAccelerometer  # noqa
-from wwSensorAngle import WWSensorAngle                  # noqa
-from wwSensorBeacon import WWSensorBeacon                # noqa
-from wwSensorButton import WWSensorButton                # noqa
-from wwSensorDistance import WWSensorDistance            # noqa
-from wwSensorGyroscope import WWSensorGyroscope          # noqa
-from wwSensorMedia import WWSensorMedia                  # noqa
-from wwSensorPing import WWSensorPing                    # noqa
-from wwSensorPose import WWSensorPose                    # noqa
-from wwSensorWheel import WWSensorWheel                  # noqa
+from .wwCommandBase import WWCommandBase                  #noqa
+from .wwCommandAccessory import WWCommandAccessory        #noqa
+from .wwCommandBody import WWCommandBody                  #noqa
+from .wwCommandEyering import WWCommandEyering            #noqa
+from .wwCommandHead import WWCommandHead                  #noqa
+from .wwCommandMedia import WWCommandMedia                #noqa
+from .wwCommandMonoLED import WWCommandMonoLED            #noqa
+from .wwCommandPing import WWCommandPing                  #noqa
+from .wwCommandRGB import WWCommandRGB                    #noqa
+from .wwMedia import WWMedia                              #noqa
+from .wwSensorAccelerometer import WWSensorAccelerometer  #noqa
+from .wwSensorAngle import WWSensorAngle                  #noqa
+from .wwSensorBeacon import WWSensorBeacon                #noqa
+from .wwSensorButton import WWSensorButton                #noqa
+from .wwSensorDistance import WWSensorDistance            #noqa
+from .wwSensorGyroscope import WWSensorGyroscope          #noqa
+from .wwSensorMedia import WWSensorMedia                  #noqa
+from .wwSensorPing import WWSensorPing                    #noqa
+from .wwSensorPose import WWSensorPose                    #noqa
+from .wwSensorWheel import WWSensorWheel                  #noqa

--- a/WonderPy/components/wwCommandAccessory.py
+++ b/WonderPy/components/wwCommandAccessory.py
@@ -1,7 +1,7 @@
 import time
 
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
+from .wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
 
 
 _rc  = WWRobotConstants.RobotComponent

--- a/WonderPy/components/wwCommandBase.py
+++ b/WonderPy/components/wwCommandBase.py
@@ -1,7 +1,8 @@
+import time
+
 from WonderPy.core.wwConstants import WWRobotConstants
 from WonderPy.core import wwMain
-from wwComponentBase import WWComponentBase
-import time
+from .wwComponentBase import WWComponentBase
 
 _rc  = WWRobotConstants.RobotComponent
 _rcv = WWRobotConstants.RobotComponentValues

--- a/WonderPy/components/wwCommandBody.py
+++ b/WonderPy/components/wwCommandBody.py
@@ -1,6 +1,6 @@
 import math
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
+from .wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
 from WonderPy.util import wwMath
 
 _rc  = WWRobotConstants.RobotComponent

--- a/WonderPy/components/wwCommandEyering.py
+++ b/WonderPy/components/wwCommandEyering.py
@@ -1,4 +1,4 @@
-from wwCommandBase import WWCommandBase
+from .wwCommandBase import WWCommandBase
 from WonderPy.core.wwConstants import WWRobotConstants
 
 _ea  = WWRobotConstants.WWEyeAnimation

--- a/WonderPy/components/wwCommandHead.py
+++ b/WonderPy/components/wwCommandHead.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
+from .wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
 from WonderPy.util import wwMath
 
 _rc  = WWRobotConstants.RobotComponent

--- a/WonderPy/components/wwCommandMedia.py
+++ b/WonderPy/components/wwCommandMedia.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
+from .wwCommandBase import WWCommandBase, do_not_call_within_connect_or_sensors
 
 _rc  = WWRobotConstants.RobotComponent
 _rcv = WWRobotConstants.RobotComponentValues

--- a/WonderPy/components/wwCommandMonoLED.py
+++ b/WonderPy/components/wwCommandMonoLED.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwCommandBase import WWCommandBase
+from .wwCommandBase import WWCommandBase
 
 _rc  = WWRobotConstants.RobotComponent
 _rcv = WWRobotConstants.RobotComponentValues

--- a/WonderPy/components/wwCommandPing.py
+++ b/WonderPy/components/wwCommandPing.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwCommandBase import WWCommandBase
+from .wwCommandBase import WWCommandBase
 
 _rc  = WWRobotConstants.RobotComponent
 _rcv = WWRobotConstants.RobotComponentValues

--- a/WonderPy/components/wwCommandRGB.py
+++ b/WonderPy/components/wwCommandRGB.py
@@ -1,4 +1,4 @@
-from wwCommandBase import WWCommandBase
+from .wwCommandBase import WWCommandBase
 from WonderPy.core.wwConstants import WWRobotConstants
 
 _rc  = WWRobotConstants.RobotComponent

--- a/WonderPy/components/wwSensorAccelerometer.py
+++ b/WonderPy/components/wwSensorAccelerometer.py
@@ -1,6 +1,6 @@
 import math
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 from WonderPy.util import wwMath
 
 _rcv = WWRobotConstants.RobotComponentValues

--- a/WonderPy/components/wwSensorAngle.py
+++ b/WonderPy/components/wwSensorAngle.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _expected_json_fields = (

--- a/WonderPy/components/wwSensorBase.py
+++ b/WonderPy/components/wwSensorBase.py
@@ -1,4 +1,4 @@
-from wwComponentBase import WWComponentBase
+from .wwComponentBase import WWComponentBase
 
 
 class WWSensorBase(WWComponentBase):

--- a/WonderPy/components/wwSensorBaseXYZ.py
+++ b/WonderPy/components/wwSensorBaseXYZ.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 from WonderPy.util import wwMath
 
 

--- a/WonderPy/components/wwSensorBeacon.py
+++ b/WonderPy/components/wwSensorBeacon.py
@@ -1,11 +1,14 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _rt  = WWRobotConstants.RobotType
 _expected_json_fields = (
     # the beacon sensor is a bit special, as we may invent empty ones.
 )
+import sys
+if sys.version_info > (3,):
+    xrange = range
 
 
 class WWSensorBeacon(WWSensorBase):

--- a/WonderPy/components/wwSensorButton.py
+++ b/WonderPy/components/wwSensorButton.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _expected_json_fields = (

--- a/WonderPy/components/wwSensorDistance.py
+++ b/WonderPy/components/wwSensorDistance.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _expected_json_fields = (

--- a/WonderPy/components/wwSensorGyroscope.py
+++ b/WonderPy/components/wwSensorGyroscope.py
@@ -1,6 +1,6 @@
 import math
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 from WonderPy.util import wwMath
 
 _rcv = WWRobotConstants.RobotComponentValues

--- a/WonderPy/components/wwSensorMedia.py
+++ b/WonderPy/components/wwSensorMedia.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _expected_json_fields = (

--- a/WonderPy/components/wwSensorPing.py
+++ b/WonderPy/components/wwSensorPing.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _expected_json_fields = (

--- a/WonderPy/components/wwSensorPose.py
+++ b/WonderPy/components/wwSensorPose.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
 import time
+from datetime import datetime, timedelta
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 from WonderPy.util import wwMath
 
 _rc  = WWRobotConstants.RobotComponent

--- a/WonderPy/components/wwSensorWheel.py
+++ b/WonderPy/components/wwSensorWheel.py
@@ -1,5 +1,5 @@
 from WonderPy.core.wwConstants import WWRobotConstants
-from wwSensorBase import WWSensorBase
+from .wwSensorBase import WWSensorBase
 
 _rcv = WWRobotConstants.RobotComponentValues
 _expected_json_fields = (

--- a/WonderPy/core/__init__.py
+++ b/WonderPy/core/__init__.py
@@ -1,5 +1,5 @@
-from wwCommands  import WWCommands  # noqa
-from wwSensors   import WWSensors   # noqa
-from wwRobot     import WWRobot     # noqa
+from .wwCommands  import WWCommands  # noqa
+from .wwSensors   import WWSensors   # noqa
+from .wwRobot     import WWRobot     # noqa
 from .           import wwBTLEMgr   # noqa
 from .           import wwMain      # noqa

--- a/WonderPy/core/wwBTLEMgr.py
+++ b/WonderPy/core/wwBTLEMgr.py
@@ -20,8 +20,8 @@ if sys.version_info > (3, 0):
 else:
     import Queue as queue
 
-from wwRobot import WWRobot
-from wwConstants import WWRobotConstants
+from .wwRobot import WWRobot
+from .wwConstants import WWRobotConstants
 from WonderPy.core import wwMain
 from WonderPy.config import WW_ROOT_DIR
 

--- a/WonderPy/core/wwRobot.py
+++ b/WonderPy/core/wwRobot.py
@@ -3,7 +3,6 @@ import sys
 
 if sys.version_info > (3, 0):
     import queue
-    long = int
 else:
     import Queue as queue
 
@@ -32,7 +31,7 @@ class WWRobot(object):
 
         self._command_queue = queue.Queue()
 
-        self._sensor_count = long(0)
+        self._sensor_count               = 0
         self._queues_waiting_for_sensors = set()
 
         self._sensors           = WWSensors (self)

--- a/WonderPy/core/wwRobot.py
+++ b/WonderPy/core/wwRobot.py
@@ -3,6 +3,7 @@ import sys
 
 if sys.version_info > (3, 0):
     import queue
+    long = int
 else:
     import Queue as queue
 


### PR DESCRIPTION
Here are the project-level changes I've made to get it running on Python 3.
There will be another PR for [BlueFruitLE](https://github.com/hawflakes/Adafruit_Python_BluefruitLE)

In a nutshell:
  - using relative imports
  - aliasing `long` to `int` due to int unification in python3
  - aliasing `xrange` to `range`

I'll update this with more as I continue to test.